### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dyslab.pro


### PR DESCRIPTION
Add CNAME file to enable custom domain dyslab.pro for GitHub Pages hosting. This will allow the website to be accessible at https://dyslab.pro instead of the default GitHub Pages URL.